### PR TITLE
added option to replace black and white to improve readability

### DIFF
--- a/gay
+++ b/gay
@@ -303,6 +303,16 @@ def _parse_args() -> Namespace:
     opt_group.add_argument(
         "--tabs", "--tab-width", type=lambda i: max(abs(int(i)), 1), default=4
     )
+    opt_group.add_argument(
+        "--black",
+        type=str,
+        default="#000000",
+    )
+    opt_group.add_argument(
+        "--white",
+        type=str,
+        default="#FFFFFF",
+    )
 
     return parser.parse_args(namespace=namespace)
 
@@ -547,7 +557,10 @@ def _main() -> None:
     with _title():
         _trap_sig()
         args = _parse_args()
-        palette = _parse_raw_palette(_FLAG_SPECS[args.flag])
+        raw_palette = _FLAG_SPECS[args.flag]
+        raw_palette = [i.replace('#000000', args.black) for i in raw_palette]
+        raw_palette = [i.replace('#FFFFFF', args.white) for i in raw_palette]
+        palette = _parse_raw_palette(raw_palette)
 
         if args.flag_only:
             flag_stripes = _paint_flag(colour_space=args.colour, palette=palette)


### PR DESCRIPTION
Comparison screenshot:
![Screenshot_20230128_173231](https://user-images.githubusercontent.com/10968473/215295914-82bf6c1c-3016-4499-9e4a-b602dc5d71da.png)

A friend of mine has a program that uses a similar method of replacing blacks and whites to improve legibility on varying backgrounds, and I figured it would be trivial to implement here. I've tested this both on my regular terminal colorscheme as well as on a white colorscheme, and it works fairly well while still keeping the flag colors recognizable.

This is a potential fix for #5.